### PR TITLE
Feat: 修改history输出

### DIFF
--- a/src/FlexiDNS/__init__.py
+++ b/src/FlexiDNS/__init__.py
@@ -4,7 +4,7 @@
 from importlib import metadata
 
 PACKAGE_NAME = __package__.split('.')[1] if len(__package__.split('.')) > 1 else __package__
-VERSION = "1.4.0.dev13"
+VERSION = "1.5.0.dev6"
 
 try:
     __version__ = metadata.version(PACKAGE_NAME)

--- a/src/FlexiDNS/command.py
+++ b/src/FlexiDNS/command.py
@@ -174,30 +174,24 @@ class CacheOperate:
 
     def history(self, args):
         # 用于history命令查询
-
         message = pickle.dumps(args)
-        recv_data = self.data_recv(message)
-        mm = recv_data.get('data')
-
-        try:
-            mmdata_bytes = pickle.loads(mm)
-        except UnpicklingError as e:
-            mmdata_bytes = []
-            print('error:', e, file=stderr, flush=True)
-
-        # 显示客户端查询历史记录
-        x = PrettyTable()
-        x.field_names = ['time', 'client', 'domain name']
-        for i in mmdata_bytes:
-            if i is not None:
-                x.add_row(
-                    (
-                        datetime.datetime.fromtimestamp(i[0]).strftime('%Y-%m-%d %H:%M:%S.%f'),
-                        i[1],
-                        i[2]
-                    )
+        self.data_recv(message)
+        hisotry = os.open(share_objects.historyfile, os.O_RDONLY)
+        while True:
+            try:
+                data = pickle.loads(os.read(hisotry, 1024))
+                print(datetime.datetime.fromtimestamp(data[0]).strftime('%Y-%m-%d %H:%M:%S.%f'),
+                      data[1].ljust(22),
+                      data[2].ljust(6),
+                      data[3],
+                      flush=True
                 )
-        print(x)
+            except UnpicklingError:
+                continue
+            except KeyboardInterrupt:
+                message = pickle.dumps({'history': {'all': False}})
+                self.data_recv(message)
+                break
 
     def _verify_args(self, args):
         error_string = "~!@#$%^&:;()_+<>,[]\\/{|}"

--- a/src/FlexiDNS/dnscache.py
+++ b/src/FlexiDNS/dnscache.py
@@ -186,7 +186,7 @@ class lrucacheout:
     def setdata(self, dnspkg):
 
         if (save_obj := self.search_cache.get(QTYPE.get(dnspkg.q.qtype))) is not None:
-            logger.debug(f'set cache {dnspkg} rcode {RCODE.get(dnspkg.response_header.get_rcode())}')
+            logger.debug(f'set cache {dnspkg} rcode {RCODE.get(dnspkg.response_header.get_rcode())}, ttl: {dnspkg.ttl}')
             tmp_data = save_obj.get(dnspkg.q.qname)
             if tmp_data is None:
                 save_obj.add_many({
@@ -194,7 +194,7 @@ class lrucacheout:
                     'rr': dnspkg.rr,
                     'auth': dnspkg.auth,
                     'rcode': dnspkg.response_header.get_rcode(),
-                    'ttl': dnsttl(dnspkg.a.ttl)
+                    'ttl': dnsttl(dnspkg.ttl)
                     }
                 })
             else:
@@ -203,7 +203,7 @@ class lrucacheout:
                     'rr': dnspkg.rr,
                     'auth': dnspkg.auth,
                     'rcode': dnspkg.response_header.get_rcode(),
-                    'ttl': dnsttl(dnspkg.a.ttl)
+                    'ttl': dnsttl(dnspkg.ttl)
                     }
                 })
         return

--- a/src/FlexiDNS/dnscli.py
+++ b/src/FlexiDNS/dnscli.py
@@ -209,13 +209,10 @@ class ManagerMmap:
         match command.get('cmd'):
             case 'show':
                 if command.get('all'):
-                    datalist = []
                     data_lengths = 0
                     self.mm.seek(0)
-                    for value in self.new_cache.cache_static.values():
-                        datalist.append(value.copy())
-                    for value in self.new_cache.search_cache.values():
-                        datalist.append(value.copy())
+                    datalist = [value.copy() for value in self.new_cache.cache_static.values()]
+                    datalist.extend(value.copy() for value in self.new_cache.search_cache.values())
                     for i in datalist:
                         data_length, data = self.__data_serialization(i)
                         data_lengths += data_length
@@ -310,6 +307,7 @@ class ManagerMmap:
                     data_length=data_length,
                     data=self.tempfile
                     )
+
     def history(self, command: dict) -> bytes:
         """用于域名对应的rule查询或修改
 
@@ -321,14 +319,14 @@ class ManagerMmap:
         """
         logger.debug(f'received command {command}')
 
-        if command.get('all'):
-            data_length, data = self.__data_serialization(share_objects.history.copy())
-            self.__write_mmap(data)
-            logger.debug(f'data length: {data_length}')
-            return self.__response_data(
-                data_length=data_length,
-                data=self.tempfile
-                )
+        share_objects.history_pipe_status = command.get('all')
+        data_length, data = self.__data_serialization(share_objects.history.copy())
+        self.__write_mmap(data)
+        logger.debug(f'data length: {share_objects.history_pipe_status}')
+        return self.__response_data(
+            data_length=data_length,
+            data=self.tempfile
+            )
 
 commandmmap = ManagerMmap()
 

--- a/src/FlexiDNS/dnsmain.py
+++ b/src/FlexiDNS/dnsmain.py
@@ -46,6 +46,8 @@ def signal_exit_server(signum, frame):
     if local_school.start_server.is_alive():
         local_school.start_server.join()
         local_school.start_server.close()
+    if os.path.exists(share_objects.historyfile):
+        os.remove(share_objects.historyfile)
 
 
 def write_pid_file(pid, PIDFILE):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -73,23 +73,26 @@ class Test_Command_history(unittest.TestCase):
         self.qname = 'www.flexidns.com'
         self.dnslabel = DNSLabel(self.qname)
         self.rr = RR(self.qname, ttl=60, rdata=A('192.168.1.1'))
-        self.history = deque([(1712404645.3993819, '::1', DNSLabel(self.qname))], maxlen=500)
+        self.history = deque([1712404645.3993819, '::1', 'SOA', self.qname], maxlen=500)
         self.history_data = pickle.dumps(self.history)
         self.cmd = {'history': {'all': True}}
 
+    @patch('os.read')
+    @patch('os.open')
     @patch('FlexiDNS.command.pickle.loads')
     @patch('FlexiDNS.command.pickle.dumps')
     @patch('FlexiDNS.command.CacheOperate.data_recv')
-    def test_03_history(self, data_recv_mock, pickle_dumps_mock, pickle_loads_mock):
+    def test_03_history(self, data_recv_mock, pickle_dumps_mock, pickle_loads_mock, open, read):
 
         pickle_dumps_mock.return_value=None
         pickle_loads_mock.return_value=self.history
+        true = False
 
-        data_recv_mock.return_value = {
-            'type': None, 'argparse': None, 'data_length': 127, 'data': self.history_data}
         with patch('builtins.print') as print_mock:
+            print_mock.side_effect = KeyboardInterrupt()
             self.command.history(self.cmd)
             print_mock.assert_called()
+        # self.command.history(self.cmd)
 
 if __name__ == '__main__':
     from os import _exit

--- a/tests/test_dnscache.py
+++ b/tests/test_dnscache.py
@@ -50,6 +50,8 @@ class Test_DnsCache(unittest.TestCase):
         dnspkg_header = DNSHeader()
         Test_DnsCache.dnspkg.add_question(DNSQuestion('www.flexidns.com'))
         Test_DnsCache.dnspkg.add_answer(RR('www.flexidns.com', ttl=60, rdata=A('192.168.1.1')))
+        Test_DnsCache.dnspkg.ttl = 60
+
         setattr(Test_DnsCache.dnspkg, 'response_header', dnspkg_header)
         self.new_cache.setdata(dnspkg=Test_DnsCache.dnspkg)
 
@@ -71,6 +73,7 @@ class Test_DnsCache_Funciton(unittest.TestCase):
         dnspkg_header = DNSHeader()
         cls.dnspkg.add_question(DNSQuestion('www.flexidns.com'))
         cls.dnspkg.add_answer(RR('www.flexidns.com', ttl=60, rdata=A('192.168.1.1')))
+        cls.dnspkg.ttl = 60
         setattr(cls.dnspkg, 'response_header', dnspkg_header)
 
     def setUp(self) -> None:

--- a/tests/test_tomlconfigure.py
+++ b/tests/test_tomlconfigure.py
@@ -41,6 +41,10 @@ class Test_ShareObject(unittest.TestCase):
         self.assertIsInstance(self.share_object.ipc_01, CircularBuffer)
         self.assertIsInstance(self.share_object.ipc_mmap_size, int)
         self.assertGreater(self.share_object.ipc_mmap_size, 1024)
+        self.assertIsInstance(self.share_object.historyfile, str)
+        self.assertIsInstance(self.share_object.history_pipe_status, bool)
+        self.assertTrue(hasattr(self.share_object, 'history_pipe_write'))
+        self.assertTrue(hasattr(self.share_object, 'history_pipe_write_fd'))
 
 
 class Test_TomlConfigure(unittest.TestCase):


### PR DESCRIPTION
1、修改history命令使用命名管道在线输出，并支持Linux命令行模式grep过滤
2、share_object添加单例
3、修复临时文件在关机时未正确清理